### PR TITLE
Remove direct dependency on quality gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 before_install:
   # https://bundler.io/blog/2019/05/14/
   #   solutions-for-cant-find-gem-bundler-with-executable-bundle.html

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,9 @@
 PATH
   remote: .
   specs:
-    pronto-bigfiles (0.1.0)
+    pronto-bigfiles (0.1.1)
       bigfiles (>= 0.2.0)
       pronto
-      quality (>= 37)
 
 GEM
   remote: https://rubygems.org/
@@ -21,7 +20,8 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    bigfiles (0.2.0)
+    bigfiles (0.2.1)
+      high_water_mark
       source_finder (>= 2)
     brakeman (4.7.2)
     bundler-audit (0.6.1)
@@ -65,6 +65,7 @@ GEM
     gitlab (4.13.1)
       httparty (~> 0.14, >= 0.14.0)
       terminal-table (~> 1.5, >= 1.5.1)
+    high_water_mark (0.1.0)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -118,9 +119,9 @@ GEM
     public_suffix (4.0.2)
     punchlist (1.3.0)
       source_finder (>= 2)
-    quality (37.0.0)
+    quality (37.1.0)
       activesupport
-      bigfiles (>= 0.1)
+      bigfiles (>= 0.1, != 0.2.0)
       brakeman
       bundler-audit
       cane (>= 2.6)
@@ -128,6 +129,7 @@ GEM
       flay (>= 2.4, != 2.6.0)
       flog (>= 4.1.1)
       github-linguist
+      high_water_mark
       json
       mdl
       punchlist (>= 1.1)

--- a/lib/pronto/bigfiles/version.rb
+++ b/lib/pronto/bigfiles/version.rb
@@ -2,6 +2,6 @@
 
 module Pronto
   module BigFilesVersion
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/pronto-bigfiles.gemspec
+++ b/pronto-bigfiles.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bigfiles', '>=0.2.0'
   spec.add_dependency 'pronto'
-  spec.add_dependency 'quality', '>= 37'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'pronto-punchlist'


### PR DESCRIPTION
This is no longer needed, as bigfiles pulls in the high_water_mark gem instead.